### PR TITLE
Add simple chat UI with Flask backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# chatflow
+# Chatflow
+
+A minimal web interface for chatting with a large language model. By default it echoes your input unless an OpenAI API key is configured.
+
+## Requirements
+
+- Python 3
+- Packages listed in `requirements.txt`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python server.py
+```
+
+Navigate to `http://localhost:5000` to start chatting.
+
+Set the environment variable `OPENAI_API_KEY` to enable responses from OpenAI's API.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Chat with LLM</title>
+<style>
+body { font-family: Arial, sans-serif; background: #f0f0f0; }
+#chat { max-width: 600px; margin: 40px auto; background: white; padding: 20px; border-radius: 8px; }
+.message { margin-bottom: 10px; }
+.user { text-align: right; color: blue; }
+.bot { text-align: left; color: green; }
+#inputArea { display: flex; margin-top: 20px; }
+#messageInput { flex: 1; padding: 8px; }
+#sendButton { padding: 8px 16px; }
+</style>
+</head>
+<body>
+<div id="chat"></div>
+<div id="inputArea">
+  <input id="messageInput" type="text" placeholder="Type your message" />
+  <button id="sendButton">Send</button>
+</div>
+<script>
+const chatDiv = document.getElementById('chat');
+const input = document.getElementById('messageInput');
+const sendButton = document.getElementById('sendButton');
+
+function appendMessage(text, className) {
+  const div = document.createElement('div');
+  div.className = 'message ' + className;
+  div.textContent = text;
+  chatDiv.appendChild(div);
+  chatDiv.scrollTop = chatDiv.scrollHeight;
+}
+
+async function sendMessage() {
+  const text = input.value.trim();
+  if (!text) return;
+  appendMessage(text, 'user');
+  input.value = '';
+  try {
+    const response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text })
+    });
+    const data = await response.json();
+    appendMessage(data.reply, 'bot');
+  } catch (err) {
+    appendMessage('Error: ' + err, 'bot');
+  }
+}
+
+sendButton.addEventListener('click', sendMessage);
+input.addEventListener('keydown', e => {
+  if (e.key === 'Enter') sendMessage();
+});
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/server.py
+++ b/server.py
@@ -1,0 +1,36 @@
+import os
+from flask import Flask, request, jsonify, send_from_directory
+
+try:
+    import openai
+    OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+    if OPENAI_KEY:
+        openai.api_key = OPENAI_KEY
+        HAVE_OPENAI = True
+    else:
+        HAVE_OPENAI = False
+except ImportError:
+    HAVE_OPENAI = False
+
+app = Flask(__name__)
+
+@app.route('/')
+def root():
+    return send_from_directory('.', 'index.html')
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    message = data.get('message', '')
+    if HAVE_OPENAI:
+        resp = openai.ChatCompletion.create(
+            model='gpt-3.5-turbo',
+            messages=[{'role': 'user', 'content': message}]
+        )
+        reply = resp.choices[0].message.content.strip()
+    else:
+        reply = f"You said: {message} (OpenAI not configured)"
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- create a minimal `index.html` page for chatting
- add `server.py` Flask backend with optional OpenAI support
- document setup and usage in `README.md`
- specify dependencies in `requirements.txt`

## Testing
- `python3 -m py_compile server.py`
- `python3 server.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6846a8b790c883279e2b1d4dff48ab5a